### PR TITLE
feat: custom request id key

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Other global parameters:
 ```go
 slogchi.TraceIDKey = "trace-id"
 slogchi.SpanIDKey = "span-id"
+slogchi.RequestIDKey = "id"
 slogchi.RequestBodyMaxSize  = 64 * 1024 // 64KB
 slogchi.ResponseBodyMaxSize = 64 * 1024 // 64KB
 slogchi.HiddenRequestHeaders = map[string]struct{}{ ... }

--- a/middleware.go
+++ b/middleware.go
@@ -18,8 +18,9 @@ type customAttributesCtxKeyType struct{}
 var customAttributesCtxKey = customAttributesCtxKeyType{}
 
 var (
-	TraceIDKey = "trace-id"
-	SpanIDKey  = "span-id"
+	TraceIDKey   = "trace-id"
+	SpanIDKey    = "span-id"
+	RequestIDKey = "id"
 
 	RequestBodyMaxSize  = 64 * 1024 // 64KB
 	ResponseBodyMaxSize = 64 * 1024 // 64KB
@@ -157,7 +158,7 @@ func NewWithConfig(logger *slog.Logger, config Config) func(http.Handler) http.H
 				}
 
 				if config.WithRequestID {
-					baseAttributes = append(baseAttributes, slog.String("id", middleware.GetReqID(r.Context())))
+					baseAttributes = append(baseAttributes, slog.String(RequestIDKey, middleware.GetReqID(r.Context())))
 				}
 
 				// otel


### PR DESCRIPTION
Current 'id' key for request id is very generic and often collides with existing ids.  

This change introduces possibility to configure request id key in a non-breaking way.   
```go
slogchi.RequestIDKey = "request_id"
```

It is made in a same way as recently introduced customization for trace/span keys. 