### PR TITLE
Store custom attributes in a map

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -260,17 +260,15 @@ func NewWithConfig(logger *slog.Logger, config Config) func(http.Handler) http.H
 }
 
 // AddCustomAttributes adds custom attributes to the request context. This func can be called from any handler, as long as the slog-chi middleware is already mounted.
-func AddCustomAttributes(r *http.Request, attr ...slog.Attr) {
-	AddContextAttributes(r.Context(), attr...)
+func AddCustomAttributes(r *http.Request, attr slog.Attr) {
+	AddContextAttributes(r.Context(), attr)
 }
 
 // AddContextAttributes is the same as AddCustomAttributes, but it doesn't need access to the request struct.
-func AddContextAttributes(ctx context.Context, attr ...slog.Attr) {
+func AddContextAttributes(ctx context.Context, attr slog.Attr) {
 	if v := ctx.Value(customAttributesCtxKey); v != nil {
 		m := v.(*sync.Map)
-		for _, a := range attr {
-			m.Store(a.Key, a.Value)
-		}
+		m.Store(attr.Key, attr.Value)
 	}
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -237,11 +237,12 @@ func NewWithConfig(logger *slog.Logger, config Config) func(http.Handler) http.H
 
 				// custom context values
 				if v := r.Context().Value(customAttributesCtxKey); v != nil {
-					m := v.(*sync.Map)
-					m.Range(func(key, value any) bool {
-						attributes = append(attributes, slog.Attr{Key: key.(string), Value: value.(slog.Value)})
-						return true
-					})
+					if m, ok := v.(*sync.Map); ok {
+						m.Range(func(key, value any) bool {
+							attributes = append(attributes, slog.Attr{Key: key.(string), Value: value.(slog.Value)})
+							return true
+						})
+					}
 				}
 
 				level := config.DefaultLevel
@@ -267,8 +268,9 @@ func AddCustomAttributes(r *http.Request, attr slog.Attr) {
 // AddContextAttributes is the same as AddCustomAttributes, but it doesn't need access to the request struct.
 func AddContextAttributes(ctx context.Context, attr slog.Attr) {
 	if v := ctx.Value(customAttributesCtxKey); v != nil {
-		m := v.(*sync.Map)
-		m.Store(attr.Key, attr.Value)
+		if m, ok := v.(*sync.Map); ok {
+			m.Store(attr.Key, attr.Value)
+		}
 	}
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -121,6 +122,11 @@ func NewWithConfig(logger *slog.Logger, config Config) func(http.Handler) http.H
 				ww.Tee(bw)
 			}
 
+			// Make sure we create a map only once per request (in case we have multiple middleware instances)
+			if v := r.Context().Value(customAttributesCtxKey); v == nil {
+				r = r.WithContext(context.WithValue(r.Context(), customAttributesCtxKey, &sync.Map{}))
+			}
+
 			defer func() {
 				// Pass thru filters and skip early the code below, to prevent unnecessary processing.
 				for _, filter := range config.Filters {
@@ -231,10 +237,11 @@ func NewWithConfig(logger *slog.Logger, config Config) func(http.Handler) http.H
 
 				// custom context values
 				if v := r.Context().Value(customAttributesCtxKey); v != nil {
-					switch attrs := v.(type) {
-					case []slog.Attr:
-						attributes = append(attributes, attrs...)
-					}
+					m := v.(*sync.Map)
+					m.Range(func(key, value any) bool {
+						attributes = append(attributes, slog.Attr{Key: key.(string), Value: value.(slog.Value)})
+						return true
+					})
 				}
 
 				level := config.DefaultLevel
@@ -252,17 +259,18 @@ func NewWithConfig(logger *slog.Logger, config Config) func(http.Handler) http.H
 	}
 }
 
-// AddCustomAttributes adds custom attributes to the request context.
-func AddCustomAttributes(r *http.Request, attr slog.Attr) {
-	v := r.Context().Value(customAttributesCtxKey)
-	if v == nil {
-		*r = *r.WithContext(context.WithValue(r.Context(), customAttributesCtxKey, []slog.Attr{attr}))
-		return
-	}
+// AddCustomAttributes adds custom attributes to the request context. This func can be called from any handler, as long as the slog-chi middleware is already mounted.
+func AddCustomAttributes(r *http.Request, attr ...slog.Attr) {
+	AddContextAttributes(r.Context(), attr...)
+}
 
-	switch attrs := v.(type) {
-	case []slog.Attr:
-		*r = *r.WithContext(context.WithValue(r.Context(), customAttributesCtxKey, append(attrs, attr)))
+// AddContextAttributes is the same as AddCustomAttributes, but it doesn't need access to the request struct.
+func AddContextAttributes(ctx context.Context, attr ...slog.Attr) {
+	if v := ctx.Value(customAttributesCtxKey); v != nil {
+		m := v.(*sync.Map)
+		for _, a := range attr {
+			m.Store(a.Key, a.Value)
+		}
 	}
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -259,7 +259,7 @@ func NewWithConfig(logger *slog.Logger, config Config) func(http.Handler) http.H
 	}
 }
 
-// AddCustomAttributes adds custom attributes to the request context. This func can be called from any handler, as long as the slog-chi middleware is already mounted.
+// AddCustomAttributes adds custom attributes to the request context. This func can be called from any handler or middleware, as long as the slog-chi middleware is already mounted.
 func AddCustomAttributes(r *http.Request, attr slog.Attr) {
 	AddContextAttributes(r.Context(), attr)
 }


### PR DESCRIPTION
Closes #9 

Hey there, since I encountered https://github.com/samber/slog-chi/issues/9 myself, I thought of this possible solution to avoid woes around  the use of `*r = r.WithContext(ctx)`

The idea is to create a `sync.Map` (a regular map would probably suffice, but a `sync.Map` can also work with calls made in  random goroutines spawned from the handler), populate it with `AddCustomAttributes`, then read it after the request ends.

Since the map is accessed via a pointer, I took the chance to also add a `AddContextAttributes` method not requiring the full-blown `*http.Request` (very useful when using Chi with [Huma](https://huma.rocks/))

With this setup, adding custom attributes can easily be done from both handlers and any middlewares mounted after `slog-chi` and other middlewares using `*r = r.WithContext(ctx)` won't interfere anymore.

Let me know if this approach sounds good, I will gladly open a PR for https://github.com/samber/slog-http, too